### PR TITLE
clashmap 2.0: hashbrown 0.17 + MSRV 1.85

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -33,7 +33,7 @@ dependencies = [
 
 [[package]]
 name = "clashmap"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "clashcore",
  "crossbeam-utils",
@@ -96,9 +96,9 @@ checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hermit-abi"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you have any suggestions or tips do not hesitate to open an issue or a PR.
 
 [![downloads](https://img.shields.io/crates/d/clashmap)](https://crates.io/crates/clashmap)
 
-[![minimum rustc version](https://img.shields.io/badge/rustc-1.70-orange.svg)](https://crates.io/crates/clashmap)
+[![minimum rustc version](https://img.shields.io/badge/rustc-1.85-orange.svg)](https://crates.io/crates/clashmap)
 
 ## Cargo features
 

--- a/crates/clashmap/Cargo.toml
+++ b/crates/clashmap/Cargo.toml
@@ -1,9 +1,9 @@
 [package]
 name = "clashmap"
-version = "1.3.0"
+version = "2.0.0"
 authors = ["Conrad Ludgate <conradludgate@gmail.com>", "Joel Wejdenstål <jwejdenstal@icloud.com>"]
 edition = "2021"
-rust-version = "1.70"
+rust-version = "1.85"
 license = "MIT"
 repository = "https://github.com/conradludgate/clashmap"
 homepage = "https://github.com/conradludgate/clashmap"
@@ -25,7 +25,7 @@ typesize = ["dep:typesize", "clashcore/typesize"]
 
 [dependencies]
 clashcore = { version = "1.0.0", path = "../clashcore" }
-hashbrown = { version = "0.15.0", default-features = false }
+hashbrown = { version = "0.17.0", default-features = false }
 crossbeam-utils = "0.8"
 replace_with = "0.1.7"
 polonius-the-crab = "0.5.0"

--- a/crates/clashmap/src/map.rs
+++ b/crates/clashmap/src/map.rs
@@ -9,7 +9,7 @@ use crate::{
     VacantEntry,
 };
 use core::fmt;
-use core::hash::{BuildHasher, Hash, Hasher};
+use core::hash::{BuildHasher, Hash};
 use core::iter::FromIterator;
 use core::ops::{BitAnd, BitOr, Shl, Shr, Sub};
 use hashbrown::Equivalent;
@@ -314,9 +314,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
     }
 
     fn hash_u64<T: Hash>(&self, item: &T) -> u64 {
-        let mut hasher = self.hasher.build_hasher();
-        item.hash(&mut hasher);
-        hasher.finish()
+        self.hasher.hash_one(item)
     }
 
     /// Returns a reference to the map's [`BuildHasher`].
@@ -596,11 +594,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
     where
         K: Hash,
     {
-        self.table.shrink_to_fit(|(k, _v)| {
-            let mut hasher = self.hasher.build_hasher();
-            k.hash(&mut hasher);
-            hasher.finish()
-        });
+        self.table.shrink_to_fit(|(k, _v)| self.hasher.hash_one(k));
     }
 
     /// Retain elements that whose predicates return true
@@ -795,15 +789,10 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
         K: Eq + Hash,
     {
         let hash = self.hash_u64(&key);
-        match self.table.entry_mut(
-            hash,
-            |(k, _v)| k == &key,
-            |(k, _v)| {
-                let mut hasher = self.hasher.build_hasher();
-                k.hash(&mut hasher);
-                hasher.finish()
-            },
-        ) {
+        match self
+            .table
+            .entry_mut(hash, |(k, _v)| k == &key, |(k, _v)| self.hasher.hash_one(k))
+        {
             crate::tableref::entrymut::EntryMut::Occupied(occupied_entry_mut) => {
                 EntryMut::Occupied(OccupiedEntryMut::new(key, occupied_entry_mut.entry))
             }
@@ -822,15 +811,10 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
         K: Eq + Hash,
     {
         let hash = self.hash_u64(&key);
-        match self.table.entry(
-            hash,
-            |(k, _v)| k == &key,
-            |(k, _v)| {
-                let mut hasher = self.hasher.build_hasher();
-                k.hash(&mut hasher);
-                hasher.finish()
-            },
-        ) {
+        match self
+            .table
+            .entry(hash, |(k, _v)| k == &key, |(k, _v)| self.hasher.hash_one(k))
+        {
             crate::tableref::entry::Entry::Occupied(entry) => {
                 Entry::Occupied(OccupiedEntry::new(entry, key))
             }
@@ -854,11 +838,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
         match self.table.entry(
             hash,
             |(k, _v)| key.equivalent(k),
-            |(k, _v)| {
-                let mut hasher = self.hasher.build_hasher();
-                k.hash(&mut hasher);
-                hasher.finish()
-            },
+            |(k, _v)| self.hasher.hash_one(k),
         ) {
             crate::tableref::entry::Entry::Occupied(entry) => {
                 let key = entry.get().0.clone();
@@ -879,15 +859,10 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
         K: Eq + Hash,
     {
         let hash = self.hash_u64(&key);
-        match self.table.try_entry(
-            hash,
-            |(k, _v)| k == &key,
-            |(k, _v)| {
-                let mut hasher = self.hasher.build_hasher();
-                k.hash(&mut hasher);
-                hasher.finish()
-            },
-        )? {
+        match self
+            .table
+            .try_entry(hash, |(k, _v)| k == &key, |(k, _v)| self.hasher.hash_one(k))?
+        {
             crate::tableref::entry::Entry::Occupied(occupied_entry) => {
                 Some(Entry::Occupied(OccupiedEntry::new(occupied_entry, key)))
             }
@@ -909,11 +884,8 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
     where
         K: Hash,
     {
-        self.table.try_reserve(additional, |(k, _v)| {
-            let mut hasher = self.hasher.build_hasher();
-            k.hash(&mut hasher);
-            hasher.finish()
-        })
+        self.table
+            .try_reserve(additional, |(k, _v)| self.hasher.hash_one(k))
     }
 }
 

--- a/crates/clashmap/src/map.rs
+++ b/crates/clashmap/src/map.rs
@@ -824,11 +824,15 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
         }
     }
 
-    /// Advanced entry API that tries to mimic `std::collections::HashMap`.
-    /// See the documentation on `clashmap::mapref::entry` for more details.
+    /// Advanced entry API that tries to mimic `std::collections::HashMap`,
+    /// keyed by a borrowed form of the key.
+    ///
+    /// The owned `K` is only materialised on insert into a vacant entry
+    /// (via [`ToOwned`]), so an `&str` lookup against a `ClashMap<String, _>`
+    /// doesn't allocate when the entry already exists.
     ///
     /// **Locking behaviour:** May deadlock if called when holding any sort of reference into the map.
-    pub fn entry_ref<Q>(&self, key: &Q) -> EntryRef<'_, K, V>
+    pub fn entry_ref<'a, 'b, Q>(&'a self, key: &'b Q) -> EntryRef<'a, 'b, K, Q, V>
     where
         Q: Hash + Equivalent<K> + ?Sized,
         K: Clone + Hash,
@@ -845,7 +849,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
                 EntryRef::Occupied(OccupiedEntry::new(entry, key))
             }
             crate::tableref::entry::Entry::Vacant(entry) => {
-                EntryRef::Vacant(VacantEntryRef::new(entry))
+                EntryRef::Vacant(VacantEntryRef::new(entry, key))
             }
         }
     }

--- a/crates/clashmap/src/map.rs
+++ b/crates/clashmap/src/map.rs
@@ -794,7 +794,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
             .entry_mut(hash, |(k, _v)| k == &key, |(k, _v)| self.hasher.hash_one(k))
         {
             crate::tableref::entrymut::EntryMut::Occupied(occupied_entry_mut) => {
-                EntryMut::Occupied(OccupiedEntryMut::new(key, occupied_entry_mut.entry))
+                EntryMut::Occupied(OccupiedEntryMut::new(occupied_entry_mut.entry))
             }
             crate::tableref::entrymut::EntryMut::Vacant(vacant_entry_mut) => {
                 EntryMut::Vacant(VacantEntryMut::new(key, vacant_entry_mut.entry))
@@ -816,7 +816,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
             .entry(hash, |(k, _v)| k == &key, |(k, _v)| self.hasher.hash_one(k))
         {
             crate::tableref::entry::Entry::Occupied(entry) => {
-                Entry::Occupied(OccupiedEntry::new(entry, key))
+                Entry::Occupied(OccupiedEntry::new(entry))
             }
             crate::tableref::entry::Entry::Vacant(entry) => {
                 Entry::Vacant(VacantEntry::new(entry, key))
@@ -835,7 +835,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
     pub fn entry_ref<'a, 'b, Q>(&'a self, key: &'b Q) -> EntryRef<'a, 'b, K, Q, V>
     where
         Q: Hash + Equivalent<K> + ?Sized,
-        K: Clone + Hash,
+        K: Hash,
     {
         let hash = self.hash_u64(&key);
 
@@ -845,8 +845,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
             |(k, _v)| self.hasher.hash_one(k),
         ) {
             crate::tableref::entry::Entry::Occupied(entry) => {
-                let key = entry.get().0.clone();
-                EntryRef::Occupied(OccupiedEntry::new(entry, key))
+                EntryRef::Occupied(OccupiedEntry::new(entry))
             }
             crate::tableref::entry::Entry::Vacant(entry) => {
                 EntryRef::Vacant(VacantEntryRef::new(entry, key))
@@ -868,7 +867,7 @@ impl<K, V, S: BuildHasher> ClashMap<K, V, S> {
             .try_entry(hash, |(k, _v)| k == &key, |(k, _v)| self.hasher.hash_one(k))?
         {
             crate::tableref::entry::Entry::Occupied(occupied_entry) => {
-                Some(Entry::Occupied(OccupiedEntry::new(occupied_entry, key)))
+                Some(Entry::Occupied(OccupiedEntry::new(occupied_entry)))
             }
             crate::tableref::entry::Entry::Vacant(vacant_entry) => {
                 Some(Entry::Vacant(VacantEntry::new(vacant_entry, key)))

--- a/crates/clashmap/src/mapref/entry.rs
+++ b/crates/clashmap/src/mapref/entry.rs
@@ -90,6 +90,19 @@ impl<'a, K, V> Entry<'a, K, V> {
             Entry::Vacant(entry) => entry.insert_entry(value),
         }
     }
+
+    /// If the entry is occupied, calls `f` with shared access to the key and
+    /// owned access to the value, replacing or removing the entry depending on
+    /// the returned `Option`. Vacant entries are returned unchanged.
+    pub fn and_replace_entry_with<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&K, V) -> Option<V>,
+    {
+        match self {
+            Entry::Occupied(entry) => entry.replace_entry_with(f),
+            Entry::Vacant(_) => self,
+        }
+    }
 }
 
 pub struct VacantEntry<'a, K, V> {
@@ -156,6 +169,29 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
     pub fn remove_entry(self) -> (K, V) {
         self.entry.remove()
     }
+
+    /// Provides shared access to the key and owned access to the value of the
+    /// entry, replacing or removing it based on the returned `Option`.
+    pub fn replace_entry_with<F>(self, f: F) -> Entry<'a, K, V>
+    where
+        F: FnOnce(&K, V) -> Option<V>,
+    {
+        let mut spare_key = None;
+        let underlying = self.entry.replace_entry_with(|(k, v)| match f(&k, v) {
+            Some(new_v) => Some((k, new_v)),
+            None => {
+                spare_key = Some(k);
+                None
+            }
+        });
+        match underlying {
+            tableref::entry::Entry::Occupied(o) => Entry::Occupied(OccupiedEntry::new(o)),
+            tableref::entry::Entry::Vacant(v) => {
+                let key = spare_key.expect("None branch must capture key");
+                Entry::Vacant(VacantEntry::new(v, key))
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -198,5 +234,46 @@ mod tests {
         drop(entry);
 
         assert_eq!(*map.get(&1).unwrap(), 2);
+    }
+
+    #[test]
+    fn test_replace_entry_with_some() {
+        let map: ClashMap<u32, u32> = ClashMap::new();
+        map.insert(1, 10);
+
+        let entry = match map.entry(1) {
+            Entry::Occupied(o) => o.replace_entry_with(|&k, v| {
+                assert_eq!(k, 1);
+                assert_eq!(v, 10);
+                Some(v + 1)
+            }),
+            Entry::Vacant(_) => unreachable!(),
+        };
+
+        assert!(matches!(&entry, Entry::Occupied(o) if *o.get() == 11));
+        drop(entry);
+        assert_eq!(*map.get(&1).unwrap(), 11);
+    }
+
+    #[test]
+    fn test_replace_entry_with_none() {
+        let map: ClashMap<u32, u32> = ClashMap::new();
+        map.insert(1, 10);
+
+        let entry = match map.entry(1) {
+            Entry::Occupied(o) => o.replace_entry_with(|_, _| None),
+            Entry::Vacant(_) => unreachable!(),
+        };
+
+        assert!(matches!(&entry, Entry::Vacant(v) if *v.key() == 1));
+        drop(entry);
+        assert!(map.get(&1).is_none());
+    }
+
+    #[test]
+    fn test_and_replace_entry_with_vacant_is_noop() {
+        let map: ClashMap<u32, u32> = ClashMap::new();
+        let entry = map.entry(1).and_replace_entry_with(|_, _| panic!());
+        assert!(matches!(entry, Entry::Vacant(_)));
     }
 }

--- a/crates/clashmap/src/mapref/entry.rs
+++ b/crates/clashmap/src/mapref/entry.rs
@@ -36,7 +36,7 @@ impl<'a, K, V> Entry<'a, K, V> {
         V: Default,
     {
         match self {
-            Entry::Occupied(entry) => entry.into_ref(),
+            Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(V::default()),
         }
     }
@@ -45,7 +45,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     /// otherwise a provided value and return a mutable reference to that.
     pub fn or_insert(self, value: V) -> RefMut<'a, K, V> {
         match self {
-            Entry::Occupied(entry) => entry.into_ref(),
+            Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(value),
         }
     }
@@ -54,7 +54,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     /// otherwise insert the result of a provided function and return a mutable reference to that.
     pub fn or_insert_with(self, value: impl FnOnce() -> V) -> RefMut<'a, K, V> {
         match self {
-            Entry::Occupied(entry) => entry.into_ref(),
+            Entry::Occupied(entry) => entry.into_mut(),
             Entry::Vacant(entry) => entry.insert(value()),
         }
     }
@@ -64,7 +64,7 @@ impl<'a, K, V> Entry<'a, K, V> {
         value: impl FnOnce() -> Result<V, E>,
     ) -> Result<RefMut<'a, K, V>, E> {
         match self {
-            Entry::Occupied(entry) => Ok(entry.into_ref()),
+            Entry::Occupied(entry) => Ok(entry.into_mut()),
             Entry::Vacant(entry) => Ok(entry.insert(value()?)),
         }
     }
@@ -74,7 +74,7 @@ impl<'a, K, V> Entry<'a, K, V> {
         match self {
             Entry::Occupied(mut entry) => {
                 entry.insert(value);
-                entry.into_ref()
+                entry.into_mut()
             }
             Entry::Vacant(entry) => entry.insert(value),
         }
@@ -141,7 +141,7 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
         mem::replace(self.get_mut(), value)
     }
 
-    pub fn into_ref(self) -> RefMut<'a, K, V> {
+    pub fn into_mut(self) -> RefMut<'a, K, V> {
         self.entry.into_mut().into()
     }
 

--- a/crates/clashmap/src/mapref/entry.rs
+++ b/crates/clashmap/src/mapref/entry.rs
@@ -29,14 +29,6 @@ impl<'a, K, V> Entry<'a, K, V> {
         }
     }
 
-    /// Into the key of the entry.
-    pub fn into_key(self) -> K {
-        match self {
-            Entry::Occupied(entry) => entry.into_key(),
-            Entry::Vacant(entry) => entry.into_key(),
-        }
-    }
-
     /// Return a mutable reference to the element if it exists,
     /// otherwise insert the default and return a mutable reference to that.
     pub fn or_default(self) -> RefMut<'a, K, V>
@@ -89,15 +81,7 @@ impl<'a, K, V> Entry<'a, K, V> {
     }
 
     /// Sets the value of the entry, and returns an OccupiedEntry.
-    ///
-    /// If you are not interested in the occupied entry,
-    /// consider [`insert`] as it doesn't need to clone the key.
-    ///
-    /// [`insert`]: Entry::insert
-    pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V>
-    where
-        K: Clone,
-    {
+    pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V> {
         match self {
             Entry::Occupied(mut entry) => {
                 entry.insert(value);
@@ -123,12 +107,8 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
     }
 
     /// Sets the value of the entry with the VacantEntry’s key, and returns an OccupiedEntry.
-    pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V>
-    where
-        K: Clone,
-    {
-        let entry = self.entry.insert_entry((self.key.clone(), value));
-        OccupiedEntry::new(entry, self.key)
+    pub fn insert_entry(self, value: V) -> OccupiedEntry<'a, K, V> {
+        OccupiedEntry::new(self.entry.insert_entry((self.key, value)))
     }
 
     pub fn into_key(self) -> K {
@@ -142,12 +122,11 @@ impl<'a, K, V> VacantEntry<'a, K, V> {
 
 pub struct OccupiedEntry<'a, K, V> {
     entry: tableref::entry::OccupiedEntry<'a, (K, V)>,
-    key: K,
 }
 
 impl<'a, K, V> OccupiedEntry<'a, K, V> {
-    pub(crate) fn new(entry: tableref::entry::OccupiedEntry<'a, (K, V)>, key: K) -> Self {
-        Self { key, entry }
+    pub(crate) fn new(entry: tableref::entry::OccupiedEntry<'a, (K, V)>) -> Self {
+        Self { entry }
     }
 
     pub fn get(&self) -> &V {
@@ -166,10 +145,6 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
         self.entry.into_mut().into()
     }
 
-    pub fn into_key(self) -> K {
-        self.key
-    }
-
     pub fn key(&self) -> &K {
         &self.entry.get().0
     }
@@ -180,13 +155,6 @@ impl<'a, K, V> OccupiedEntry<'a, K, V> {
 
     pub fn remove_entry(self) -> (K, V) {
         self.entry.remove()
-    }
-
-    pub fn replace_entry(self, value: V) -> (K, V) {
-        // SAFETY: `_guard` is bound for the remainder of the function, so it
-        // outlives every use of `t`.
-        let (_guard, t) = unsafe { self.entry.into_mut().into_raw_parts() };
-        mem::replace(t, (self.key, value))
     }
 }
 

--- a/crates/clashmap/src/mapref/entry_ref.rs
+++ b/crates/clashmap/src/mapref/entry_ref.rs
@@ -1,231 +1,40 @@
 use super::one::RefMut;
 use crate::{tableref, OccupiedEntry};
 
-pub enum EntryRef<'a, K, V> {
+/// A view into a single entry in a map keyed by a borrowed form of the key.
+///
+/// Constructed via [`ClashMap::entry_ref`](crate::ClashMap::entry_ref). The
+/// owned key is only materialised on insert (via [`ToOwned`]), so callers can
+/// look up by `&str` against `ClashMap<String, _>`, `&Path` against
+/// `ClashMap<PathBuf, _>`, etc., without paying the allocation when the entry
+/// is already occupied.
+pub enum EntryRef<'a, 'b, K, Q: ?Sized, V> {
     Occupied(OccupiedEntry<'a, K, V>),
-    Vacant(VacantEntryRef<'a, K, V>),
+    Vacant(VacantEntryRef<'a, 'b, K, Q, V>),
 }
 
-// impl<'a, K, V> EntryRef<'a, K, V> {
-//     /// Apply a function to the stored value if it exists.
-//     pub fn and_modify(self, f: impl FnOnce(&mut V)) -> Self {
-//         match self {
-//             EntryRef::Occupied(mut entry) => {
-//                 f(entry.get_mut());
-
-//                 EntryRef::Occupied(entry)
-//             }
-
-//             EntryRef::Vacant(entry) => EntryRef::Vacant(entry),
-//         }
-//     }
-
-//     /// Get the key of the entry.
-//     pub fn key(&self) -> &K {
-//         match *self {
-//             EntryRef::Occupied(ref entry) => entry.key(),
-//             EntryRef::Vacant(ref entry) => entry.key(),
-//         }
-//     }
-
-//     /// Into the key of the entry.
-//     pub fn into_key(self) -> K {
-//         match self {
-//             EntryRef::Occupied(entry) => entry.into_key(),
-//             EntryRef::Vacant(entry) => entry.into_key(),
-//         }
-//     }
-
-//     /// Return a mutable reference to the element if it exists,
-//     /// otherwise insert the default and return a mutable reference to that.
-//     pub fn or_default(self) -> RefMut<'a, K, V>
-//     where
-//         V: Default,
-//     {
-//         match self {
-//             EntryRef::Occupied(entry) => entry.into_ref(),
-//             EntryRef::Vacant(entry) => entry.insert(V::default()),
-//         }
-//     }
-
-//     /// Return a mutable reference to the element if it exists,
-//     /// otherwise a provided value and return a mutable reference to that.
-//     pub fn or_insert(self, value: V) -> RefMut<'a, K, V> {
-//         match self {
-//             EntryRef::Occupied(entry) => entry.into_ref(),
-//             EntryRef::Vacant(entry) => entry.insert(value),
-//         }
-//     }
-
-//     /// Return a mutable reference to the element if it exists,
-//     /// otherwise insert the result of a provided function and return a mutable reference to that.
-//     pub fn or_insert_with(self, value: impl FnOnce() -> V) -> RefMut<'a, K, V> {
-//         match self {
-//             EntryRef::Occupied(entry) => entry.into_ref(),
-//             EntryRef::Vacant(entry) => entry.insert(value()),
-//         }
-//     }
-
-//     pub fn or_try_insert_with<E>(
-//         self,
-//         value: impl FnOnce() -> Result<V, E>,
-//     ) -> Result<RefMut<'a, K, V>, E> {
-//         match self {
-//             EntryRef::Occupied(entry) => Ok(entry.into_ref()),
-//             EntryRef::Vacant(entry) => Ok(entry.insert(value()?)),
-//         }
-//     }
-
-//     /// Sets the value of the entry, and returns a reference to the inserted value.
-//     pub fn insert(self, key: K,value: V) -> RefMut<'a, K, V> {
-//         match self {
-//             EntryRef::Occupied(mut entry) => {
-//                 entry.insert(value);
-//                 entry.into_ref()
-//             }
-//             EntryRef::Vacant(entry) => entry.insert(value),
-//         }
-//     }
-
-//     /// Sets the value of the entry, and returns an OccupiedEntry.
-//     ///
-//     /// If you are not interested in the occupied entry,
-//     /// consider [`insert`] as it doesn't need to clone the key.
-//     ///
-//     /// [`insert`]: Entry::insert
-//     pub fn insert_entry(self, key: K, value: V) -> OccupiedEntry<'a, K, V>
-//     where
-//         K: Clone,
-//     {
-//         match self {
-//             EntryRef::Occupied(mut entry) => {
-//                 entry.insert(value);
-//                 entry
-//             }
-//             EntryRef::Vacant(entry) => entry.insert_entry(key, value),
-//         }
-//     }
-// }
-
-pub struct VacantEntryRef<'a, K, V> {
+/// A view into a vacant entry obtained from [`EntryRef`].
+///
+/// Holds the borrowed lookup key and only materialises an owned `K` (via
+/// [`ToOwned`]) when [`insert`](Self::insert) is called.
+pub struct VacantEntryRef<'a, 'b, K, Q: ?Sized, V> {
     entry: tableref::entry::VacantEntry<'a, (K, V)>,
+    key: &'b Q,
 }
 
-impl<'a, K, V> VacantEntryRef<'a, K, V> {
-    pub(crate) fn new(entry: tableref::entry::VacantEntry<'a, (K, V)>) -> Self {
-        Self { entry }
+impl<'a, 'b, K, Q: ?Sized, V> VacantEntryRef<'a, 'b, K, Q, V> {
+    pub(crate) fn new(entry: tableref::entry::VacantEntry<'a, (K, V)>, key: &'b Q) -> Self {
+        Self { entry, key }
     }
 
-    pub fn insert(self, key: K, value: V) -> RefMut<'a, K, V> {
-        let occupied = self.entry.insert((key, value));
-        RefMut::from(occupied)
+    pub fn key(&self) -> &Q {
+        self.key
     }
 
-    /// Sets the value of the entry with the VacantEntry’s key, and returns an OccupiedEntry.
-    pub fn insert_entry(self, key: K, value: V) -> OccupiedEntry<'a, K, V>
+    pub fn insert(self, value: V) -> RefMut<'a, K, V>
     where
-        K: Clone,
+        Q: ToOwned<Owned = K>,
     {
-        let entry = self.entry.insert_entry((key.clone(), value));
-        OccupiedEntry::new(entry, key)
+        self.entry.insert((self.key.to_owned(), value)).into()
     }
 }
-
-// pub struct OccupiedEntry<'a, K, V> {
-//     guard: RwLockWriteGuardDetached<'a>,
-//     entry: hash_table::OccupiedEntry<'a, (K, V)>,
-//     key: K,
-// }
-
-// impl<'a, K, V> OccupiedEntry<'a, K, V> {
-//     pub(crate) fn new(
-//         guard: RwLockWriteGuardDetached<'a>,
-//         key: K,
-//         entry: hash_table::OccupiedEntry<'a, (K, V)>,
-//     ) -> Self {
-//         Self { guard, key, entry }
-//     }
-
-//     pub fn get(&self) -> &V {
-//         &self.entry.get().1
-//     }
-
-//     pub fn get_mut(&mut self) -> &mut V {
-//         &mut self.entry.get_mut().1
-//     }
-
-//     pub fn insert(&mut self, value: V) -> V {
-//         mem::replace(self.get_mut(), value)
-//     }
-
-//     pub fn into_ref(self) -> RefMut<'a, K, V> {
-//         let (k, v) = self.entry.into_mut();
-//         RefMut::new(self.guard, k, v)
-//     }
-
-//     pub fn into_key(self) -> K {
-//         self.key
-//     }
-
-//     pub fn key(&self) -> &K {
-//         &self.entry.get().0
-//     }
-
-//     pub fn remove(self) -> V {
-//         let ((_k, v), _) = self.entry.remove();
-//         v
-//     }
-
-//     pub fn remove_entry(self) -> (K, V) {
-//         let ((k, v), _) = self.entry.remove();
-//         (k, v)
-//     }
-
-//     pub fn replace_entry(self, value: V) -> (K, V) {
-//         let (k, v) = mem::replace(self.entry.into_mut(), (self.key, value));
-//         (k, v)
-//     }
-// }
-
-// #[cfg(test)]
-// mod tests {
-//     use crate::ClashMap;
-
-//     use super::*;
-
-//     #[test]
-//     fn test_insert_entry_into_vacant() {
-//         let map: ClashMap<u32, u32> = ClashMap::new();
-
-//         let entry = map.entry(1);
-
-//         assert!(matches!(entry, EntryRef::Vacant(_)));
-
-//         let entry = entry.insert_entry(2);
-
-//         assert_eq!(*entry.get(), 2);
-
-//         drop(entry);
-
-//         assert_eq!(*map.get(&1).unwrap(), 2);
-//     }
-
-//     #[test]
-//     fn test_insert_entry_into_occupied() {
-//         let map: ClashMap<u32, u32> = ClashMap::new();
-
-//         map.insert(1, 1000);
-
-//         let entry = map.entry(1);
-
-//         assert!(matches!(&entry, EntryRef::Occupied(entry) if *entry.get() == 1000));
-
-//         let entry = entry.insert_entry(2);
-
-//         assert_eq!(*entry.get(), 2);
-
-//         drop(entry);
-
-//         assert_eq!(*map.get(&1).unwrap(), 2);
-//     }
-// }

--- a/crates/clashmap/src/mapref/entrymut.rs
+++ b/crates/clashmap/src/mapref/entrymut.rs
@@ -91,6 +91,19 @@ impl<'a, K: Eq + Hash, V> EntryMut<'a, K, V> {
             EntryMut::Vacant(entry) => entry.insert_entry(value),
         }
     }
+
+    /// If the entry is occupied, calls `f` with shared access to the key and
+    /// owned access to the value, replacing or removing the entry depending on
+    /// the returned `Option`. Vacant entries are returned unchanged.
+    pub fn and_replace_entry_with<F>(self, f: F) -> Self
+    where
+        F: FnOnce(&K, V) -> Option<V>,
+    {
+        match self {
+            EntryMut::Occupied(entry) => entry.replace_entry_with(f),
+            EntryMut::Vacant(_) => self,
+        }
+    }
 }
 
 pub struct VacantEntryMut<'a, K, V> {
@@ -160,6 +173,29 @@ impl<'a, K: Eq + Hash, V> OccupiedEntryMut<'a, K, V> {
     pub fn remove_entry(self) -> (K, V) {
         let ((k, v), _) = self.entry.remove();
         (k, v)
+    }
+
+    /// Provides shared access to the key and owned access to the value of the
+    /// entry, replacing or removing it based on the returned `Option`.
+    pub fn replace_entry_with<F>(self, f: F) -> EntryMut<'a, K, V>
+    where
+        F: FnOnce(&K, V) -> Option<V>,
+    {
+        let mut spare_key = None;
+        let underlying = self.entry.replace_entry_with(|(k, v)| match f(&k, v) {
+            Some(new_v) => Some((k, new_v)),
+            None => {
+                spare_key = Some(k);
+                None
+            }
+        });
+        match underlying {
+            hash_table::Entry::Occupied(o) => EntryMut::Occupied(OccupiedEntryMut::new(o)),
+            hash_table::Entry::Vacant(v) => {
+                let key = spare_key.expect("None branch must capture key");
+                EntryMut::Vacant(VacantEntryMut::new(key, v))
+            }
+        }
     }
 }
 

--- a/crates/clashmap/src/mapref/entrymut.rs
+++ b/crates/clashmap/src/mapref/entrymut.rs
@@ -30,14 +30,6 @@ impl<'a, K: Eq + Hash, V> EntryMut<'a, K, V> {
         }
     }
 
-    /// Into the key of the entry.
-    pub fn into_key(self) -> K {
-        match self {
-            EntryMut::Occupied(entry) => entry.into_key(),
-            EntryMut::Vacant(entry) => entry.into_key(),
-        }
-    }
-
     /// Return a mutable reference to the element if it exists,
     /// otherwise insert the default and return a mutable reference to that.
     pub fn or_default(self) -> &'a mut (K, V)
@@ -90,15 +82,7 @@ impl<'a, K: Eq + Hash, V> EntryMut<'a, K, V> {
     }
 
     /// Sets the value of the entry, and returns an OccupiedEntry.
-    ///
-    /// If you are not interested in the occupied entry,
-    /// consider [`insert`] as it doesn't need to clone the key.
-    ///
-    /// [`insert`]: EntryMut::insert
-    pub fn insert_entry(self, value: V) -> OccupiedEntryMut<'a, K, V>
-    where
-        K: Clone,
-    {
+    pub fn insert_entry(self, value: V) -> OccupiedEntryMut<'a, K, V> {
         match self {
             EntryMut::Occupied(mut entry) => {
                 entry.insert(value);
@@ -125,13 +109,9 @@ impl<'a, K: Eq + Hash, V> VacantEntryMut<'a, K, V> {
     }
 
     /// Sets the value of the entry with the VacantEntry’s key, and returns an OccupiedEntry.
-    pub fn insert_entry(self, value: V) -> OccupiedEntryMut<'a, K, V>
-    where
-        K: Clone,
-    {
-        let entry = self.entry.insert((self.key.clone(), value));
-
-        OccupiedEntryMut::new(self.key, entry)
+    pub fn insert_entry(self, value: V) -> OccupiedEntryMut<'a, K, V> {
+        let entry = self.entry.insert((self.key, value));
+        OccupiedEntryMut::new(entry)
     }
 
     pub fn into_key(self) -> K {
@@ -145,12 +125,11 @@ impl<'a, K: Eq + Hash, V> VacantEntryMut<'a, K, V> {
 
 pub struct OccupiedEntryMut<'a, K, V> {
     entry: hash_table::OccupiedEntry<'a, (K, V)>,
-    key: K,
 }
 
 impl<'a, K: Eq + Hash, V> OccupiedEntryMut<'a, K, V> {
-    pub(crate) fn new(key: K, entry: hash_table::OccupiedEntry<'a, (K, V)>) -> Self {
-        Self { key, entry }
+    pub(crate) fn new(entry: hash_table::OccupiedEntry<'a, (K, V)>) -> Self {
+        Self { entry }
     }
 
     pub fn get(&self) -> &V {
@@ -169,10 +148,6 @@ impl<'a, K: Eq + Hash, V> OccupiedEntryMut<'a, K, V> {
         self.entry.into_mut()
     }
 
-    pub fn into_key(self) -> K {
-        self.key
-    }
-
     pub fn key(&self) -> &K {
         &self.entry.get().0
     }
@@ -184,11 +159,6 @@ impl<'a, K: Eq + Hash, V> OccupiedEntryMut<'a, K, V> {
 
     pub fn remove_entry(self) -> (K, V) {
         let ((k, v), _) = self.entry.remove();
-        (k, v)
-    }
-
-    pub fn replace_entry(self, value: V) -> (K, V) {
-        let (k, v) = mem::replace(self.entry.into_mut(), (self.key, value));
         (k, v)
     }
 }

--- a/crates/clashmap/src/read_only.rs
+++ b/crates/clashmap/src/read_only.rs
@@ -8,7 +8,6 @@ use core::hash::{BuildHasher, Hash};
 use crossbeam_utils::CachePadded;
 use hashbrown::Equivalent;
 use std::collections::hash_map::RandomState;
-use std::hash::Hasher;
 
 /// A read-only view into a `ClashMap`. Allows to obtain raw references to the stored values.
 pub struct ReadOnlyView<K, V, S = RandomState> {
@@ -74,11 +73,7 @@ impl<K, V, S> ReadOnlyView<K, V, S> {
 
 impl<'a, K: 'a + Eq + Hash, V: 'a, S: BuildHasher> ReadOnlyView<K, V, S> {
     fn hash_u64<T: Hash>(&self, item: &T) -> u64 {
-        let mut hasher = self.hasher.build_hasher();
-
-        item.hash(&mut hasher);
-
-        hasher.finish()
+        self.hasher.hash_one(item)
     }
 
     fn _determine_shard(&self, hash: usize) -> usize {

--- a/crates/clashmap/src/tableref/entry.rs
+++ b/crates/clashmap/src/tableref/entry.rs
@@ -176,16 +176,14 @@ impl<'a, T> OccupiedEntry<'a, T> {
 #[cfg(test)]
 mod tests {
     use std::collections::hash_map::RandomState;
-    use std::hash::{BuildHasher, Hash, Hasher};
+    use std::hash::{BuildHasher, Hash};
 
     use crate::ClashTable;
 
     use super::*;
 
     fn hash_one(s: &impl BuildHasher, h: impl Hash) -> u64 {
-        let mut s = s.build_hasher();
-        h.hash(&mut s);
-        s.finish()
+        s.hash_one(&h)
     }
 
     #[test]

--- a/crates/clashmap/src/tableref/entry.rs
+++ b/crates/clashmap/src/tableref/entry.rs
@@ -166,11 +166,6 @@ impl<'a, T> OccupiedEntry<'a, T> {
         let (t, _) = self.entry.remove();
         t
     }
-
-    pub fn replace_entry(self, value: T) -> T {
-        let t = mem::replace(self.entry.into_mut(), value);
-        t
-    }
 }
 
 #[cfg(test)]

--- a/crates/clashmap/src/tableref/entry.rs
+++ b/crates/clashmap/src/tableref/entry.rs
@@ -156,6 +156,21 @@ impl<'a, T> OccupiedEntry<'a, T> {
         let (t, _) = self.entry.remove();
         t
     }
+
+    /// Provides owned access to the value of the entry and allows to replace
+    /// or remove it based on the value of the returned option.
+    ///
+    /// The hash of the new item must be the same as the old item, otherwise
+    /// future lookups for the new item may fail to find it.
+    pub fn replace_entry_with<F>(self, f: F) -> Entry<'a, T>
+    where
+        F: FnOnce(T) -> Option<T>,
+    {
+        match self.entry.replace_entry_with(f) {
+            hash_table::Entry::Occupied(o) => Entry::Occupied(OccupiedEntry::new(self.guard, o)),
+            hash_table::Entry::Vacant(v) => Entry::Vacant(VacantEntry::new(self.guard, v)),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/crates/clashmap/src/tableref/entry.rs
+++ b/crates/clashmap/src/tableref/entry.rs
@@ -2,7 +2,6 @@ use hashbrown::hash_table;
 
 use super::one::RefMut;
 use clashcore::lock::RwLockWriteGuardDetached;
-use core::mem;
 
 pub enum Entry<'a, T> {
     Occupied(OccupiedEntry<'a, T>),
@@ -67,7 +66,7 @@ impl<'a, T> Entry<'a, T> {
     pub fn insert(self, value: T) -> RefMut<'a, T> {
         match self {
             Entry::Occupied(mut entry) => {
-                entry.insert(value);
+                *entry.get_mut() = value;
                 entry.into_mut()
             }
             Entry::Vacant(entry) => entry.insert(value),
@@ -75,15 +74,10 @@ impl<'a, T> Entry<'a, T> {
     }
 
     /// Sets the value of the entry, and returns an OccupiedEntry.
-    ///
-    /// If you are not interested in the occupied entry,
-    /// consider [`insert`] as it doesn't need to clone the key.
-    ///
-    /// [`insert`]: Entry::insert
     pub fn insert_entry(self, value: T) -> OccupiedEntry<'a, T> {
         match self {
             Entry::Occupied(mut entry) => {
-                entry.insert(value);
+                *entry.get_mut() = value;
                 entry
             }
             Entry::Vacant(entry) => entry.insert_entry(value),
@@ -152,10 +146,6 @@ impl<'a, T> OccupiedEntry<'a, T> {
 
     pub fn get_mut(&mut self) -> &mut T {
         self.entry.get_mut()
-    }
-
-    pub fn insert(&mut self, value: T) -> T {
-        mem::replace(self.get_mut(), value)
     }
 
     pub fn into_mut(self) -> RefMut<'a, T> {

--- a/crates/clashmap/src/tableref/entrymut.rs
+++ b/crates/clashmap/src/tableref/entrymut.rs
@@ -1,7 +1,5 @@
 use hashbrown::hash_table;
 
-use core::mem;
-
 pub enum EntryMut<'a, T> {
     Occupied(OccupiedEntryMut<'a, T>),
     Vacant(VacantEntryMut<'a, T>),
@@ -65,7 +63,7 @@ impl<'a, T> EntryMut<'a, T> {
     pub fn insert(self, value: T) -> &'a mut T {
         match self {
             EntryMut::Occupied(mut entry) => {
-                entry.insert(value);
+                *entry.get_mut() = value;
                 entry.into_mut()
             }
             EntryMut::Vacant(entry) => entry.insert(value),
@@ -73,15 +71,10 @@ impl<'a, T> EntryMut<'a, T> {
     }
 
     /// Sets the value of the entry, and returns an OccupiedEntry.
-    ///
-    /// If you are not interested in the occupied entry,
-    /// consider [`insert`] as it doesn't need to clone the key.
-    ///
-    /// [`insert`]: EntryMut::insert
     pub fn insert_entry(self, value: T) -> OccupiedEntryMut<'a, T> {
         match self {
             EntryMut::Occupied(mut entry) => {
-                entry.insert(value);
+                *entry.get_mut() = value;
                 entry
             }
             EntryMut::Vacant(entry) => entry.insert_entry(value),
@@ -125,10 +118,6 @@ impl<'a, T> OccupiedEntryMut<'a, T> {
 
     pub fn get_mut(&mut self) -> &mut T {
         self.entry.get_mut()
-    }
-
-    pub fn insert(&mut self, value: T) -> T {
-        mem::replace(self.get_mut(), value)
     }
 
     pub fn into_mut(self) -> &'a mut T {

--- a/crates/clashmap/src/tableref/entrymut.rs
+++ b/crates/clashmap/src/tableref/entrymut.rs
@@ -133,4 +133,19 @@ impl<'a, T> OccupiedEntryMut<'a, T> {
         let (v, e) = self.entry.remove();
         (v, VacantEntryMut::new(e))
     }
+
+    /// Provides owned access to the value of the entry and allows to replace
+    /// or remove it based on the value of the returned option.
+    ///
+    /// The hash of the new item must be the same as the old item, otherwise
+    /// future lookups for the new item may fail to find it.
+    pub fn replace_entry_with<F>(self, f: F) -> EntryMut<'a, T>
+    where
+        F: FnOnce(T) -> Option<T>,
+    {
+        match self.entry.replace_entry_with(f) {
+            hash_table::Entry::Occupied(o) => EntryMut::Occupied(OccupiedEntryMut::new(o)),
+            hash_table::Entry::Vacant(v) => EntryMut::Vacant(VacantEntryMut::new(v)),
+        }
+    }
 }

--- a/crates/clashmap/src/tableref/iter.rs
+++ b/crates/clashmap/src/tableref/iter.rs
@@ -139,14 +139,12 @@ impl<'a, T: 'a> Iterator for IterMut<'a, T> {
 #[cfg(test)]
 mod tests {
     use std::collections::hash_map::RandomState;
-    use std::hash::{BuildHasher, Hash, Hasher};
+    use std::hash::{BuildHasher, Hash};
 
     use crate::ClashTable;
 
     fn hash_one(s: &impl BuildHasher, h: impl Hash) -> u64 {
-        let mut s = s.build_hasher();
-        h.hash(&mut s);
-        s.finish()
+        s.hash_one(&h)
     }
 
     #[test]

--- a/crates/clashmap/src/tableref/one.rs
+++ b/crates/clashmap/src/tableref/one.rs
@@ -11,14 +11,12 @@ pub type MappedRefMut<'a, T> = RefMut<'a, T>;
 #[cfg(test)]
 mod tests {
     use std::collections::hash_map::RandomState;
-    use std::hash::{BuildHasher, Hash, Hasher};
+    use std::hash::{BuildHasher, Hash};
 
     use crate::ClashTable;
 
     fn hash_one(s: &impl BuildHasher, h: impl Hash) -> u64 {
-        let mut s = s.build_hasher();
-        h.hash(&mut s);
-        s.finish()
+        s.hash_one(&h)
     }
 
     #[test]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.70"
+channel = "1.85"
 components = ["rustfmt", "clippy"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

- Bumps `hashbrown` from 0.15 to 0.17 in `clashmap`.
- Bumps `clashmap` to 2.0.0 (MSRV 1.70 → 1.85, required by hashbrown 0.17).
- `clashcore` stays at 1.0 — it doesn't depend on `hashbrown` and its API is unchanged.
- Replaces the manual `build_hasher → hash → finish` boilerplate with `BuildHasher::hash_one` (stable since 1.76, now in MSRV).
- **Aligns the entry API with hashbrown 0.17.** Mirrors hashbrown's `EntryRef`/`OccupiedEntry`/`replace_entry_with` shapes; removes legacy methods that hashbrown no longer exposes.

## Compatibility with hashbrown 0.17 breaking changes

`hashbrown` 0.17 only breaks on:
- **`EntryRef`** — we use our own `EntryRef` type, not hashbrown's.
- **`get_many_mut` → `get_disjoint_mut`** — not used in clashmap.
- **`DefaultHashBuilder`** — not used; we default to `std::collections::hash_map::RandomState`.

## Entry-API changes (mirroring hashbrown 0.17)

- `EntryRef<'a, K, V>` is now `EntryRef<'a, 'b, K, Q: ?Sized, V>`. `VacantEntryRef::insert` no longer takes a key — the key is derived from the borrowed lookup via `ToOwned`, so `entry_ref(&"foo")` against `ClashMap<String, _>` no longer allocates when the entry is occupied. `EntryRef::Occupied` reuses the existing `OccupiedEntry`.
- `OccupiedEntry` / `OccupiedEntryMut` no longer carry a duplicated `key: K` field — the key is read from the table on demand, matching hashbrown.
- `K: Clone` is dropped from `ClashMap::entry_ref`, `Entry::insert_entry`, `VacantEntry::insert_entry` and the `_mut` twins.
- `OccupiedEntry::into_ref` is renamed to `into_mut` (return type stays `RefMut<'a, K, V>` because we still need the shard guard alive alongside the borrow).
- Methods removed because hashbrown 0.17 doesn't have them:
  - `OccupiedEntry::into_key` and `Entry::into_key` (and `_mut` twins)
  - `OccupiedEntry::replace_entry(value) -> (K, V)` (and `_mut` twin)
  - `tableref::OccupiedEntry::replace_entry(value) -> T` (and `_mut` twin)
  - `tableref::OccupiedEntry::insert(&mut self, value: T) -> T` (and `_mut` twin) — `mapref::OccupiedEntry::insert` is kept since hashbrown's `hash_map::OccupiedEntry::insert` exists with the same signature
- New methods adopted from hashbrown 0.17:
  - `OccupiedEntry::replace_entry_with(F: FnOnce(&K, V) -> Option<V>)` and `Entry::and_replace_entry_with` (and `_mut` twins)
  - `tableref::OccupiedEntry::replace_entry_with(F: FnOnce(T) -> Option<T>)` (and `_mut` twin)

## Other breaking changes

- MSRV bumped to **1.85**.

## Commits (each a small reviewable step)

1. `feat(clashmap)!: bump to 2.0.0 with hashbrown 0.17 and MSRV 1.85`
2. `refactor(clashmap): use BuildHasher::hash_one`
3. `feat(clashmap)!: align EntryRef with hashbrown 0.17 (ToOwned-based)`
4. `refactor(clashmap)!: drop stored key from OccupiedEntry to match hashbrown`
5. `refactor(clashmap)!: rename OccupiedEntry::into_ref to into_mut`
6. `refactor(clashmap)!: drop tableref::OccupiedEntry::replace_entry`
7. `refactor(clashmap)!: drop tableref OccupiedEntry/OccupiedEntryMut::insert`
8. `feat(clashmap): adopt hashbrown's replace_entry_with / and_replace_entry_with`

## Test plan

- [x] `cargo build --workspace --all-features` on Rust 1.85
- [x] `cargo test --workspace --all-features` (46 unit + 56 doc, all passing)
- [x] `cargo clippy --workspace --all-features -- -D warnings`
- [x] `cargo doc --workspace --all-features --no-deps`
- [ ] Cross-target CI matrix passes (handled by the existing `ci.yml` workflow)

Closes #3.